### PR TITLE
Fix - Update stream names, update supported python version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![test](https://github.com/DanielPDWalker/tap-theme-parks/actions/workflows/test.yml/badge.svg)](https://github.com/DanielPDWalker/tap-theme-parks/actions/workflows/test.yml)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 <a href="https://github.com/DanielPDWalker/tap-theme-parks/master/LICENSE"><img alt="GitHub license" src="https://img.shields.io/github/license/DanielPDWalker/tap-theme-parks"></a>
-[![Python](https://img.shields.io/static/v1?logo=python&label=python&message=3.7%20|%203.8%20|%203.9&color=blue)]()
+[![Python](https://img.shields.io/static/v1?logo=python&label=python&message=3.7%20|%203.8%20|%203.9%20|%203.10%20|%203.11&color=blue)]()
 
 `tap-theme-parks` is a Singer tap for theme park data from [themeparks.wiki](https://themeparks.wiki/) API, built with the [Meltano Tap SDK](https://sdk.meltano.com) for Singer Taps.
 

--- a/tap_theme_parks/streams.py
+++ b/tap_theme_parks/streams.py
@@ -7,10 +7,10 @@ from singer_sdk import typing as th  # JSON Schema typing helpers
 from tap_theme_parks.client import ThemeParksStream
 
 
-class DestinationsStream(ThemeParksStream):
-    """Define destinations stream"""
+class DestinationStream(ThemeParksStream):
+    """Define destination stream"""
 
-    name = "destinations"
+    name = "destination"
     path = "/destinations"
     primary_keys = ["id"]
     replication_key = None
@@ -38,10 +38,10 @@ class DestinationsStream(ThemeParksStream):
         }
 
 
-class ParkDetailsStream(ThemeParksStream):
-    """Define park details stream"""
+class ParkDetailStream(ThemeParksStream):
+    """Define park detail stream"""
 
-    parent_stream_type = DestinationsStream
+    parent_stream_type = DestinationStream
     name = "park_detail"
     path_template = "/entity/{park_id}"
     primary_keys = ["id"]
@@ -79,7 +79,7 @@ class ParkDetailsStream(ThemeParksStream):
 class ParkChildrenStream(ThemeParksStream):
     """Define park children stream"""
 
-    parent_stream_type = ParkDetailsStream
+    parent_stream_type = ParkDetailStream
     name = "park_children"
     path = "/entity/{park_id}/children"
     primary_keys = ["id"]
@@ -105,10 +105,10 @@ class ParkChildrenStream(ThemeParksStream):
     ).to_dict()
 
 
-class DestinationDetailsStream(ThemeParksStream):
-    """Define destination details stream"""
+class DestinationDetailStream(ThemeParksStream):
+    """Define destination detail stream"""
 
-    parent_stream_type = DestinationsStream
+    parent_stream_type = DestinationStream
     name = "destination_detail"
     path = "/entity/{destination_id}"
     primary_keys = ["id"]
@@ -137,7 +137,7 @@ class DestinationDetailsStream(ThemeParksStream):
 class DestinationChildrenStream(ThemeParksStream):
     """Define destination children stream"""
 
-    parent_stream_type = DestinationsStream
+    parent_stream_type = DestinationStream
     name = "destination_children"
     path = "/entity/{destination_id}/children"
     primary_keys = ["id"]

--- a/tap_theme_parks/tap.py
+++ b/tap_theme_parks/tap.py
@@ -24,10 +24,10 @@ class TapThemeParks(Tap):
             A list of discovered streams.
         """
         selected_streams = [
-            streams.DestinationsStream(self),
-            streams.DestinationDetailsStream(self),
+            streams.DestinationStream(self),
+            streams.DestinationDetailStream(self),
             streams.DestinationChildrenStream(self),
-            streams.ParkDetailsStream(self),
+            streams.ParkDetailStream(self),
             streams.ParkChildrenStream(self),
         ]
 


### PR DESCRIPTION
closes #22 

- Updated stream names in the tap
- Updated `destinations` output table to singular `destination`
- Updated the Python versions in this project's README